### PR TITLE
added ability to write plugins directly in moonboots config

### DIFF
--- a/lib/compile-stylus.js
+++ b/lib/compile-stylus.js
@@ -19,7 +19,7 @@ module.exports = function (options, done) {
 
         if (util.isArray(plugins)) {
             plugins.forEach(function (plugin) {
-                if(plugin === plugin.toString()) {
+                if(typeof plugin === 'string') {
                     var p = prequire(plugin);
                     compiler.use(p());
                 } else {
@@ -28,7 +28,7 @@ module.exports = function (options, done) {
             });
         } else {
             Object.keys(plugins).forEach(function (plugin) {
-                if(plugin === plugin.toString()) {
+                if(typeof plugin === 'string') {
                     var p = prequire(plugin);
                     compiler.use(p(plugins[plugin]));
                 } else {

--- a/lib/compile-stylus.js
+++ b/lib/compile-stylus.js
@@ -19,13 +19,21 @@ module.exports = function (options, done) {
 
         if (util.isArray(plugins)) {
             plugins.forEach(function (plugin) {
-                var p = prequire(plugin);
-                compiler.use(p());
+                if(plugin === plugin.toString()) {
+                    var p = prequire(plugin);
+                    compiler.use(p());
+                } else {
+                    compiler.use(plugin);
+                }
             });
         } else {
             Object.keys(plugins).forEach(function (plugin) {
-                var p = prequire(plugin);
-                compiler.use(p(plugins[plugin]));
+                if(plugin === plugin.toString()) {
+                    var p = prequire(plugin);
+                    compiler.use(p(plugins[plugin]));
+                } else {
+                    compiler.use(plugin);
+                }
             });
         }
 


### PR DESCRIPTION
Once I needed an ability to write custom plugins for stylus through the moonboots. For example, I wanted to define global variable with path to images dir. But with existing functionality of stylizer I can't do like this:

```javascript
stylizer({
          infile: cssDir + '/app.styl',
          outfile: cssDir + '/app.css',
          development: true,
          watch: cssDir + '/**/*.styl',
          plugins: [
            function(stl) {
              stl.define('$imgpath', config.client.prefix + config.client.public + 'images/');
            }
          ]
        }, done);
```

I added few lines of code to provide the ability to write plugins in this way.

Is it good idea to do it?