### PR TITLE
Switch out gaze for chokidar for node 0.12 and io.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "author": "Philip Roberts",
   "bin": "./bin/cli",
   "dependencies": {
+    "chokidar": "^1.0.0-rc3",
     "cssesc": "~0.1.0",
-    "gaze": "~0.6.4",
     "minimist": "^1.1.0",
     "parent-require": "~1.0.0",
     "request": "~2.44.0",

--- a/stylizer.js
+++ b/stylizer.js
@@ -38,24 +38,23 @@ var livereloadWatch = function (infile, watchDir, compileFn) {
     if (watching[infile]) return;
 
     console.log('Setting up watch');
-    var gaze = require('gaze');
+    var chokidar = require('chokidar');
 
-    gaze(watchDir, function (err, watcher) {
-        watcher.on('all', function (event, filepath) {
-            console.log('Changed:', filepath);
-            var url = 'http://localhost:' + port + '/changed?files=meeting.css';
+    var watcher = chokidar.watch(watchDir);
+    watcher.on('all', function (event, filepath) {
+        console.log('Changed:', filepath);
+        var url = 'http://localhost:' + port + '/changed?files=meeting.css';
 
-            if (compileFn) {
-                compileFn(function (err) {
-                    request.get(url);
-                });
-            } else {
+        if (compileFn) {
+            compileFn(function (err) {
                 request.get(url);
-            }
-        });
-        watching[infile] = true;
-        console.log('Watching', watchDir);
+            });
+        } else {
+            request.get(url);
+        }
     });
+    watching[infile] = true;
+    console.log('Watching', watchDir);
 };
 
 var cssError = require('./lib/css-error');


### PR DESCRIPTION
Stylizer depends on [gaze](https://www.npmjs.com/package/gaze) for notifications of file changes, but gaze is currently incompatible with node 0.12 and io.js.  There's an issue around that - shama/gaze#173 but it looks like he wants to fix it by using the native portion of [navelgazer](https://www.npmjs.com/package/navelgazer) instead.

All lovely but it doesn't get us much closer to 0.12/io.js compatibility.  This pull request swaps gaze out for the very similar looking [chokidar](https://www.npmjs.com/package/chokidar) which does exactly the same job and has 0.12/io.js compatibility today.